### PR TITLE
Removes entity ID normalization.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,6 @@ module github.com/joesiltberg/bowness
 go 1.13
 
 require (
-	github.com/PuerkitoBio/purell v1.1.1
-	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/lestrrat-go/jwx/v2 v2.0.8
 	github.com/spf13/viper v1.10.1
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0

--- a/go.sum
+++ b/go.sum
@@ -49,10 +49,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
-github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
-github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
-github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -454,7 +450,6 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1/go.mod h1:9tjilg8BloeKEkVJvy7fQ90B1CfIiPueXVOjqfkSzI8=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 h1:CIJ76btIcR3eFI5EgSo6k1qKw9KJexJuRLI9G7Hp5wE=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/PuerkitoBio/purell"
 	"github.com/joesiltberg/bowness/fedtls"
 )
 
@@ -24,10 +23,9 @@ const (
 )
 
 const (
-	entityIDHeader           string = "X-FedTLSAuth-Entity-ID"
-	normalizedEntityIDHeader        = "X-FedTLSAuth-Normalized-Entity-ID"
-	organizationHeader              = "X-FedTLSAuth-Organization"
-	organizationIDHeader            = "X-FedTLSAuth-Organization-ID"
+	entityIDHeader       string = "X-FedTLSAuth-Entity-ID"
+	organizationHeader          = "X-FedTLSAuth-Organization"
+	organizationIDHeader        = "X-FedTLSAuth-Organization-ID"
 )
 
 // EntityIDFromContext returns the authenticated entity ID
@@ -37,26 +35,6 @@ const (
 // is in place before the request handler.
 func EntityIDFromContext(ctx context.Context) string {
 	return ctx.Value(entityIDKey).(string)
-}
-
-func normalizeEntityID(entityID string) string {
-	normalized, err := purell.NormalizeURLString(entityID, purell.FlagsSafe)
-	if err != nil {
-		// This shouldn't happen assuming the federation ensures all entity ids are
-		// valid URIs
-		return entityID
-	} else {
-		return normalized
-	}
-}
-
-// NormalizedEntityIDFromContext returns the authenticated entity ID in normalized form.
-//
-// Normalized for is more appropriate for comparing entity ids or when an entity id is
-// used as a key for lookup.
-func NormalizedEntityIDFromContext(ctx context.Context) string {
-	entityID := EntityIDFromContext(ctx)
-	return normalizeEntityID(entityID)
 }
 
 // OrganizationFromContext returns the peer's organization or nil
@@ -128,7 +106,6 @@ func AuthMiddleware(h http.Handler, mdstore *fedtls.MetadataStore) http.Handler 
 		r2 := r.Clone(newContext)
 
 		r2.Header.Set(entityIDHeader, entityID)
-		r2.Header.Set(normalizedEntityIDHeader, normalizeEntityID(entityID))
 		setOrClear(r2.Header, organizationHeader, org)
 		setOrClear(r2.Header, organizationIDHeader, orgID)
 


### PR DESCRIPTION
Normalized form shouldn't be used anyway and by removing it we get rid of a dependency.