### PR TITLE
The MetadataStore now limits the size of downloaded metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 #### Security fixes
   - The MetadataStore now uses a timeout when fetching metadata (#26)
   - Fixed unchecked type assertion in JWS expiration header parsing (#28)
+  - The MetadataStore now limits the size of downloaded metadata (#30)
 
 ## v1.2.0 (2026-03-27)
 #### New features

--- a/README.md
+++ b/README.md
@@ -122,6 +122,17 @@ fails (typically due to network error).
 `BadContentRetry` determines how often we re-try when there's a problem
 verifying or parsing the metadata.
 
+You can also configure the maximum allowed size (in MiB) for a metadata
+response. This protects against out-of-memory conditions if a metadata
+server returns an unexpectedly large response:
+
+```
+MaxMetadataSize: 50
+```
+
+The default is 50 MiB, which should be more than enough for most federation
+metadata.
+
 If you want to use an API key when making requests to the backend:
 
 ```

--- a/cmd/bowness/main.go
+++ b/cmd/bowness/main.go
@@ -85,6 +85,7 @@ func main() {
 	viper.SetDefault("EnableLimiting", false)
 	viper.SetDefault("LimitRequestsPerSecond", 10.0)
 	viper.SetDefault("LimitBurst", 50)
+	viper.SetDefault("MaxMetadataSize", 50)
 
 	var versionFlag bool
 	flag.BoolVar(&versionFlag, "version", false, "display program version and exit")
@@ -132,7 +133,8 @@ func main() {
 		viper.GetString("CachePath"),
 		fedtls.DefaultCacheTTL(configuredSeconds("DefaultCacheTTL")),
 		fedtls.NetworkRetry(configuredSeconds("NetworkRetry")),
-		fedtls.BadContentRetry(configuredSeconds("BadContentRetry")))
+		fedtls.BadContentRetry(configuredSeconds("BadContentRetry")),
+		fedtls.MaxMetadataSize(int64(viper.GetInt("MaxMetadataSize"))*1024*1024))
 
 	certFile := viper.GetString("Cert")
 	keyFile := viper.GetString("Key")

--- a/fedtls/metadatastore.go
+++ b/fedtls/metadatastore.go
@@ -52,6 +52,9 @@ type MetadataStoreOptions struct {
 
 	// Timeout for HTTP requests when fetching metadata
 	FetchTimeout time.Duration
+
+	// Maximum size in bytes of a metadata response body
+	MaxMetadataSize int64
 }
 
 // An OptionSetter is a function for modifying the metadata store options
@@ -85,6 +88,13 @@ func FetchTimeout(duration time.Duration) OptionSetter {
 	}
 }
 
+// MaxMetadataSize creates an OptionSetter for setting the maximum metadata response size in bytes
+func MaxMetadataSize(size int64) OptionSetter {
+	return func(options *MetadataStoreOptions) {
+		options.MaxMetadataSize = size
+	}
+}
+
 // NewMetadataStore constructs a new MetadataStore and starts its goroutine
 func NewMetadataStore(url, jwksPath, cachedPath string, setters ...OptionSetter) *MetadataStore {
 	ms := MetadataStore{
@@ -98,6 +108,7 @@ func NewMetadataStore(url, jwksPath, cachedPath string, setters ...OptionSetter)
 		NetworkRetry:    1 * time.Minute,
 		BadContentRetry: 1 * time.Hour,
 		FetchTimeout:    30 * time.Second,
+		MaxMetadataSize: 50 * 1024 * 1024, // 50 MiB
 	}
 
 	for _, setter := range setters {
@@ -164,7 +175,7 @@ type fetchResult struct {
 }
 
 // An async HTTP GET, sends its result to a channel
-func fetch(url string, client *http.Client, fetched chan<- fetchResult) {
+func fetch(url string, client *http.Client, maxSize int64, fetched chan<- fetchResult) {
 	log.Printf("Fetching new metadata from %s", url)
 	go func() {
 		response, err := client.Get(url)
@@ -172,10 +183,16 @@ func fetch(url string, client *http.Client, fetched chan<- fetchResult) {
 		if err != nil {
 			fetched <- fetchResult{nil, err}
 		} else {
-			body, err := io.ReadAll(response.Body)
-			fetched <- fetchResult{body, err}
+			body, err := io.ReadAll(io.LimitReader(response.Body, maxSize+1))
 			//nolint:errcheck
 			response.Body.Close()
+			if err != nil {
+				fetched <- fetchResult{nil, err}
+			} else if int64(len(body)) > maxSize {
+				fetched <- fetchResult{nil, fmt.Errorf("metadata response exceeds maximum size (%d bytes)", maxSize)}
+			} else {
+				fetched <- fetchResult{body, nil}
+			}
 		}
 	}()
 }
@@ -318,7 +335,7 @@ func metadataFetcher(
 				}
 			}
 		case <-retry:
-			fetch(url, client, fetched)
+			fetch(url, client, options.MaxMetadataSize, fetched)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #30